### PR TITLE
fix issue where --findRelatedTests overrides --testPathPattern

### DIFF
--- a/integration-tests/__tests__/find_related_files.test.js
+++ b/integration-tests/__tests__/find_related_files.test.js
@@ -23,6 +23,7 @@ SkipOnWindows.suite();
 beforeEach(() => cleanup(DIR));
 afterEach(() => cleanup(DIR));
 
+//this is correct
 test('runs tests related to filename', () => {
   writeFiles(DIR, {
     '.watchmanconfig': '',
@@ -41,5 +42,81 @@ test('runs tests related to filename', () => {
   expect(stderr).toMatch('PASS __tests__/test.test.js');
 
   const summaryMsg = 'Ran all test suites related to files matching /a.js/i.';
+  expect(stderr).toMatch(summaryMsg);
+});
+
+//this is correct
+test('runs tests when path matches', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    '__tests__/test.test.js': `
+      const a = require('../a');
+      test('a', () => {});
+    `,
+    'a.js': 'module.exports = {};',
+    'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+  });
+
+  const {stdout} = runJest(DIR, ['a.js']);
+  expect(stdout).toMatch('');
+
+  const {stderr} = runJest(DIR, [
+    '--testPathPattern',
+    '__tests__',
+  ]);
+  expect(stderr).toMatch('PASS __tests__/test.test.js');
+
+  const summaryMsg = 'Ran all test suites matching /__tests__/i.';
+  expect(stderr).toMatch(summaryMsg);
+});
+
+//this is correct
+test('does not run test when filename does not match but path matches', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    '__tests__/test.test.js': `
+      const a = require('../a');
+      test('a', () => {});
+    `,
+    'a.js': 'module.exports = {};',
+    'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+  });
+
+  const {stdout} = runJest(DIR, [
+    '--testPathPattern',
+    '__tests__',
+    '--findRelatedTests',
+    'foo.js',
+  ]);
+  expect(stdout).toMatch('No tests found');
+
+  const summaryMsg = 'Pattern: foo.js|__tests__ - 0 matches';
+  expect(stdout).toMatch(summaryMsg);
+});
+
+// this is a bug
+test('runs tests when filename matches but path does not match', () => {
+  writeFiles(DIR, {
+    '.watchmanconfig': '',
+    '__tests__/test.test.js': `
+      const a = require('../a');
+      test('a', () => {});
+    `,
+    'a.js': 'module.exports = {};',
+    'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
+  });
+
+  const {stdout} = runJest(DIR, ['a.js']);
+  expect(stdout).toMatch('');
+
+  const {stderr} = runJest(DIR, [
+    '--testPathPattern',
+    'abcdd',
+    '--findRelatedTests',
+    'a.js',
+  ]);
+  expect(stderr).toMatch('PASS __tests__/test.test.js');
+
+  const summaryMsg = 'Ran all test suites related to files matching /a.js|abcdd/i.';
   expect(stderr).toMatch(summaryMsg);
 });


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

<!-- Please remember to update CHANGELOG.md in the root of the project if you have not done so. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

This pull request is meant to begin addressing `https://github.com/facebook/jest/issues/5129`.

The current problem is that when using the following two CLI options together, `--testPathPattern` and `--findRelatedTests`, tests will be run if the test pattern does not match but the related test is found.

## Test plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

I wrote an integration test to assert that this regression exists.

```
yarn jest integration-tests/__tests__/find_related_files.test.js
```

```
//from integration-tests/__tests__/find_related_files.test.js:98
// this is a bug
test('runs tests when filename matches but path does not match', () => {
  writeFiles(DIR, {
    '.watchmanconfig': '',
    '__tests__/test.test.js': `
      const a = require('../a');
      test('a', () => {});
    `,
    'a.js': 'module.exports = {};',
    'package.json': JSON.stringify({jest: {testEnvironment: 'node'}}),
  });

  const {stdout} = runJest(DIR, ['a.js']);
  expect(stdout).toMatch('');

  const {stderr} = runJest(DIR, [
    '--testPathPattern',
    'abcdd',
    '--findRelatedTests',
    'a.js',
  ]);
  expect(stderr).toMatch('PASS __tests__/test.test.js');

  const summaryMsg = 'Ran all test suites related to files matching /a.js|abcdd/i.';
  expect(stderr).toMatch(summaryMsg);
});

```

## Strategy

1. The first is to summarize the issue in my own words so that I understand what my scope will be. I haven't worked with this repository before and I haven't read all of the documentation, so this a good first step. Based on the issue description, it looks like the Jest CLI appears to have unexpected behavior when using 2 options together, --testPathPattern and --findRelatedTests. A maintainer of the project confirmed that --findRelatedTests shouldn't override  --testPathPattern when used together and welcomed a pull request to fix it. Part of clarifying the issue is also commenting on the pull request to let them know that I'm taking a look at it. 

2. I next pulled down the repo that demonstrates this buggy behavior (https://github.com/emilgoldsmith/jest-bug) and confirmed it was happening on my end. The bad behavior is that tests would be run if --testPathPattern does not match but --findRelatedTests matches. The expected behavior is --testPathPattern should also act as a filter in addition to --findRelatedTests.

3. Next is to read Jest documentation on the intended use of these CLI options as well as read the contribution guidelines. Once I did that, I then created a branch off my fork and proceeded with getting my development environment ready.

4. Next is I made sure I understood the developer lifecycle so I could successfully iterate on my solution. It looks like Jest uses yarn to build its source to a target directory and I noticed it has a suite of integration tests that use that build directory to run their assertions. 

5. Once I was all set up, I wanted to write a test to prove that the bug was happening on the most recent version of Jest. The integration test directory looked like a good place to start, so I wrote additional tests here: jest/integration-tests/__tests__/find_related_files.test.js.

6. After confirming my bug successfully and writing a failing test, I proceeded to explore the repository. I went immediately to the jest-cli package and limited my scope to its source directory. 

7. Since I knew the names of my CLI options but did not know where they were implemented or used, I did a combination of grepping for their names in the source code and I used the Github search feature to find any commits that contained the CLI option names. 

8. I got lucky and found this commit: https://github.com/facebook/jest/commit/bb5408d49063d0f554fa86d8eb0fcc43c74df2b5 that points to where the findRelatedTests options were originally implemented. This particular commit adds functionalty to a search_source.js file, which seemed very promising. At this point, I knew I wanted to find the code that was parsing the various options and trying to run a search on the test files, and I was able to find the source of the bug right here: https://github.com/polinadotio/jest/blob/master/packages/jest-cli/src/search_source.js#L193. 

9. The bug turns out to be an ordering problem. The current config options (testPathPattern, findRelatedTests, runTestsByPath, and onlyChanged) are checked in a specific order in a way that does not allow their search results to be used together. In the case that was reported by my issue, findRelatedTests is currently overriding testPathPattern because there is an if check for findRelatedTests before there is an if check for testPathPattern, so the results of testPathPattern are never checked! 

10. Next is to consider my options to resolving this bug. In order to allow the CLI options to be used together, checking for them has to be order agnostic, and I need to be able to find a way to combine the search results such that that they return a Promise in a way that takes the intersection of the test files found. 

11. I also need to consider my constraints. I do not want to increase the scope of my fix beyond the specific issue of 2 CLI options being used together, and I do not want to introduce a regression since I see that the options are being checked in a specific order. Another potential complication is that some of the options return custom meta data in addition to the "test" result array. 

12. Given these constraints in mind, my first step could be adding functionality to check if any available options currently exist and combine their "test" result arrays at the end and try to return their combined meta data in addition to the resulting array. I'm hoping the current repo tests will fail if I've introduced a regression at this point.

13. At this point I've also played around with updating search_source.js and noticing that I can indeed get my integration tests to pass if I change the order of the option checks. Once I decide on a first iteration for my solution, I also add my own unit tests to search_source.js.

14. Once I've completed tests that I feel validate the basic change I want to make (returning combined test file results), I wait for CI feedback on the rest of the tests in the repository, and at this point I feel ready for some developer feedback in the form of posting a PR. Before doing more work, I want to be flexible to alternate fixes and want to be mindful of the maintainer's feedback and perspective, since their roadmap and org needs ultimately dictate whether my pull request is reasonable. 

15. Additional things I may need to consider is whether there needs to be a documentation update as a result of this fix. It might be worth it to call out how one can use the CLI options together and what the expected behavior should be.